### PR TITLE
Policy index#4

### DIFF
--- a/app/controllers/api/v1/policies_controller.rb
+++ b/app/controllers/api/v1/policies_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::PoliciesController < ApplicationController
+  def index
+    render json: PolicySerializer.new(Policy.all)
+  end
+end

--- a/app/serializers/policy_serializer.rb
+++ b/app/serializers/policy_serializer.rb
@@ -1,0 +1,4 @@
+class PolicySerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :id, :policy_type, :division, :carrier_id, :client_id, :effective_date, :expiration_date, :written_premium, :carrier_policy_number
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       resources :carriers, only: [:index]
       resources :clients, only: [:index]
+      resources :policies, only: [:index]
     end
   end
 end

--- a/spec/factories/policy.rb
+++ b/spec/factories/policy.rb
@@ -1,0 +1,12 @@
+FactoryBot.define do
+  factory :policy do
+    policy_type { "General Liability" }
+    division { "Chicago" }
+    carrier_id { "613" }
+    client_id { "36" }
+    effective_date { "2017-05-02" }
+    expiration_date { "2018-05-02" }
+    written_premium { "11850" }
+    carrier_policy_number { "2052636" }
+  end
+end

--- a/spec/requests/api/v1/policy_request_spec.rb
+++ b/spec/requests/api/v1/policy_request_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+describe 'Policy API' do
+  it "displays a list of policies" do
+    carrier_1 = create(:carrier)
+    carrier_2 = create(:carrier)
+    client_1 = create(:client)
+    client_2 = create(:client)
+    policy_1 = create(:policy, carrier_id: carrier_1.id, client_id: client_1.id)
+    policy_2 = create(:policy, carrier_id: carrier_2.id, client_id: client_1.id)
+    policy_3 = create(:policy, carrier_id: carrier_1.id, client_id: client_2.id)
+    get '/api/v1/policies'
+
+    expect(response).to be_successful
+
+    policies = JSON.parse(response.body)
+
+    expect(policies.count).to eq(1)
+    expect(policies["data"].count).to eq(3)
+    expect(policies["data"][0]["attributes"]["id"]).to eq(policy_1.id)
+    expect(policies["data"][0]["attributes"]["carrier_id"]).to eq(carrier_1.id)
+    expect(policies["data"][0]["attributes"]["client_id"]).to eq(client_1.id)
+
+    expect(policies["data"][1]["attributes"]["id"]).to eq(policy_2.id)
+    expect(policies["data"][1]["attributes"]["carrier_id"]).to eq(carrier_2.id)
+    expect(policies["data"][1]["attributes"]["client_id"]).to eq(client_1.id)
+
+    expect(policies["data"][2]["attributes"]["id"]).to eq(policy_3.id)
+    expect(policies["data"][2]["attributes"]["carrier_id"]).to eq(carrier_1.id)
+    expect(policies["data"][2]["attributes"]["client_id"]).to eq(client_2.id)
+  end
+end


### PR DESCRIPTION
- Closes #4 
GET /api/v1/policies

- Adds test setup for policy request index; all tests passing; 100% coverage

- Adds policy serializer

- Includes index method within policies controller and namespaced index route for policies