### PR TITLE
Find policy by effective date#15

### DIFF
--- a/app/controllers/api/v1/policies/search_controller.rb
+++ b/app/controllers/api/v1/policies/search_controller.rb
@@ -8,6 +8,8 @@ class Api::V1::Policies::SearchController < ApplicationController
   def index
     if params[:expiration_date]
       render json: PolicySerializer.new(Policy.where(expiration_date: params[:expiration_date]))
+    elsif params[:effective_date]
+      render json: PolicySerializer.new(Policy.where(effective_date: params[:effective_date]))
     end
   end
 end

--- a/spec/requests/api/v1/policy_request_spec.rb
+++ b/spec/requests/api/v1/policy_request_spec.rb
@@ -61,5 +61,19 @@ describe 'Policy API' do
       expect(policies["data"][0]["attributes"]["expiration_date"]).to eq(policy_1.expiration_date)
       expect(policies["data"][1]["attributes"]["expiration_date"]).to eq(policy_2.expiration_date)
     end
+    it "can find all policies by effective_date" do
+      carrier = create(:carrier)
+      carrier_2 = create(:carrier, company_name: "Not Bluths")
+      client = create(:client)
+      policy_1 = create(:policy, carrier_id: carrier.id, client_id: client.id, effective_date: "2018-03-02", carrier_policy_number: "12345678")
+      policy_2 = create(:policy, carrier_id: carrier_2.id, client_id: client.id, effective_date: "2018-03-02", carrier_policy_number: "987654321")
+
+      get "/api/v1/policies/find_all?effective_date=#{policy_1.effective_date}"
+
+      policies = JSON.parse(response.body)
+      expect(response).to be_successful
+      expect(policies["data"][0]["attributes"]["effective_date"]).to eq(policy_1.effective_date)
+      expect(policies["data"][1]["attributes"]["effective_date"]).to eq(policy_2.effective_date)
+    end
   end
 end


### PR DESCRIPTION
- Closes #15 
GET /api/v1/policies/find_all?effective_date=date

- Adds test for finding policies by effective date

- Adds search by effective date to policy search controller