### PR TITLE
Total counts#18

### DIFF
--- a/app/controllers/api/v1/carriers/count_controller.rb
+++ b/app/controllers/api/v1/carriers/count_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Carriers::CountController < ApplicationController
+  def show
+    render json: Carrier.count
+  end
+end

--- a/app/controllers/api/v1/clients/count_controller.rb
+++ b/app/controllers/api/v1/clients/count_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Clients::CountController < ApplicationController
+  def show
+    render json: Client.count
+  end
+end

--- a/app/controllers/api/v1/policies/count_controller.rb
+++ b/app/controllers/api/v1/policies/count_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::Policies::CountController < ApplicationController
+  def show
+    render json: Policy.count
+  end
+end

--- a/app/controllers/api/v1/policies/search_controller.rb
+++ b/app/controllers/api/v1/policies/search_controller.rb
@@ -8,6 +8,8 @@ class Api::V1::Policies::SearchController < ApplicationController
   def index
     if params[:expiration_date]
       render json: PolicySerializer.new(Policy.where(expiration_date: params[:expiration_date]))
+    elsif params[:effective_date]
+      render json: PolicySerializer.new(Policy.where(effective_date: params[:effective_date]))
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,13 +4,16 @@ Rails.application.routes.draw do
     namespace :v1 do
       namespace :carriers do
         get "/find", to: 'search#show'
+        get "/total_count", to: 'count#show'
       end
       namespace :clients do
         get "/find", to: 'search#show'
+        get "/total_count", to: 'count#show'
       end
       namespace :policies do
         get "/find", to: 'search#show'
         get "/find_all", to: 'search#index'
+        get "/total_count", to: 'count#show'
       end
       resources :carriers, only: [:index]
       resources :clients, only: [:index]

--- a/spec/requests/api/v1/carrier_request_spec.rb
+++ b/spec/requests/api/v1/carrier_request_spec.rb
@@ -25,4 +25,12 @@ describe 'Carrier API' do
       expect(carrier["data"]["attributes"]["company_name"]).to_not eq(carrier_2.company_name)
     end
   end
+  it "returns a total count of all carriers" do
+    create_list(:carrier, 5)
+    get "/api/v1/carriers/total_count"
+
+    carrier_count = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(carrier_count).to eq(5)
+  end
 end

--- a/spec/requests/api/v1/client_request_spec.rb
+++ b/spec/requests/api/v1/client_request_spec.rb
@@ -25,4 +25,12 @@ describe 'Client API' do
       expect(client["data"]["attributes"]["name"]).to_not eq(client_2.name)
     end
   end
+  it "returns a total count of all clients" do
+    create_list(:client, 5)
+    get "/api/v1/clients/total_count"
+
+    client_count = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(client_count).to eq(5)
+  end
 end

--- a/spec/requests/api/v1/policy_request_spec.rb
+++ b/spec/requests/api/v1/policy_request_spec.rb
@@ -76,4 +76,21 @@ describe 'Policy API' do
       expect(policies["data"][1]["attributes"]["effective_date"]).to eq(policy_2.effective_date)
     end
   end
+  it "returns a total count of all policies" do
+    carrier = create(:carrier)
+    carrier_2 = create(:carrier, company_name: "Not Bluths")
+    client = create(:client)
+    client_2 = create(:client, name: "Lucille 2")
+    policy_1 = create(:policy, carrier_id: carrier.id, client_id: client.id, carrier_policy_number: "12345678")
+    policy_2 = create(:policy, carrier_id: carrier_2.id, client_id: client.id, carrier_policy_number: "987654321")
+    policy_3 = create(:policy, carrier_id: carrier_2.id, client_id: client_2.id, carrier_policy_number: "907654321")
+    policy_4 = create(:policy, carrier_id: carrier.id, client_id: client.id, carrier_policy_number: "981154321")
+    policy_5 = create(:policy, carrier_id: carrier.id, client_id: client_2.id, carrier_policy_number: "297654321")
+
+    get "/api/v1/policies/total_count"
+
+    policy_count = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(policy_count).to eq(5)
+  end
 end


### PR DESCRIPTION
Closes #18 

Adds test setup for finding total counts of carriers, clients, & policies; all tests passing; 100% coverage

Adds namespaced routes for total counts for carriers, clients, & policies

Adds show method to count controller for all 3 models