### PR TITLE
Policies by client#19

### DIFF
--- a/app/controllers/api/v1/clients/policies_controller.rb
+++ b/app/controllers/api/v1/clients/policies_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Clients::PoliciesController < ApplicationController
+  def index
+    policies = Client.find(params[:id]).policies
+    render json: PolicySerializer.new(policies)
+  end
+end

--- a/app/controllers/api/v1/clients_controller.rb
+++ b/app/controllers/api/v1/clients_controller.rb
@@ -2,4 +2,8 @@ class Api::V1::ClientsController < ApplicationController
   def index
     render json: ClientSerializer.new(Client.all)
   end
+
+  def show
+    render json: ClientSerializer.new(Client.find(params[:id]))
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
       namespace :clients do
         get "/find", to: 'search#show'
         get "/total_count", to: 'count#show'
+        get "/:id/policies", to: 'policies#index'
       end
       namespace :policies do
         get "/find", to: 'search#show'
@@ -16,7 +17,7 @@ Rails.application.routes.draw do
         get "/total_count", to: 'count#show'
       end
       resources :carriers, only: [:index]
-      resources :clients, only: [:index]
+      resources :clients, only: [:index, :show]
       resources :policies, only: [:index]
     end
   end

--- a/spec/requests/api/v1/client_request_spec.rb
+++ b/spec/requests/api/v1/client_request_spec.rb
@@ -12,6 +12,15 @@ describe 'Client API' do
     expect(clients.count).to eq(1)
     expect(clients["data"].count).to eq(3)
   end
+  it "returns one client by its id" do
+    client_1 = create(:client)
+
+    get "/api/v1/clients/#{client_1.id}"
+
+    client = JSON.parse(response.body)
+    expect(response).to be_successful
+    expect(client["data"]["id"]).to eq(client_1.id.to_s)
+  end
   context 'paramter find search' do
     it "can find a single client by name" do
       client_1 = create(:client)
@@ -32,5 +41,27 @@ describe 'Client API' do
     client_count = JSON.parse(response.body)
     expect(response).to be_successful
     expect(client_count).to eq(5)
+  end
+  context "client relationships" do
+    it "returns all policies for a single client" do
+      client_1 = create(:client)
+      client_2 = create(:client)
+      carrier_1 = create(:carrier)
+
+      policy_1 = create(:policy, carrier_id: carrier_1.id, client_id: client_1.id, carrier_policy_number: "12345678")
+      policy_2 = create(:policy, carrier_id: carrier_1.id, client_id: client_1.id, carrier_policy_number: "987654321")
+      policy_3 = create(:policy, carrier_id: carrier_1.id, client_id: client_2.id, carrier_policy_number: "784536123")
+
+      get "/api/v1/clients/#{client_1.id}/policies"
+
+      expect(response).to be_successful
+      policies = JSON.parse(response.body)
+
+      expect(policies["data"].count).to eq(2)
+      expect(policies["data"][0]["attributes"]["client_id"]).to eq(client_1.id)
+      expect(policies["data"][0]["attributes"]["client_id"]).to_not eq(client_2.id)
+      expect(policies["data"][1]["attributes"]["client_id"]).to eq(client_1.id)
+      expect(policies["data"][1]["attributes"]["client_id"]).to_not eq(client_2.id)
+    end
   end
 end

--- a/spec/requests/api/v1/policy_request_spec.rb
+++ b/spec/requests/api/v1/policy_request_spec.rb
@@ -17,15 +17,12 @@ describe 'Policy API' do
 
     expect(policies.count).to eq(1)
     expect(policies["data"].count).to eq(3)
-    expect(policies["data"][0]["attributes"]["id"]).to eq(policy_1.id)
     expect(policies["data"][0]["attributes"]["carrier_id"]).to eq(carrier_1.id)
     expect(policies["data"][0]["attributes"]["client_id"]).to eq(client_1.id)
 
-    expect(policies["data"][1]["attributes"]["id"]).to eq(policy_2.id)
     expect(policies["data"][1]["attributes"]["carrier_id"]).to eq(carrier_2.id)
     expect(policies["data"][1]["attributes"]["client_id"]).to eq(client_1.id)
 
-    expect(policies["data"][2]["attributes"]["id"]).to eq(policy_3.id)
     expect(policies["data"][2]["attributes"]["carrier_id"]).to eq(carrier_1.id)
     expect(policies["data"][2]["attributes"]["client_id"]).to eq(client_2.id)
   end


### PR DESCRIPTION
- Closes #19 
GET /api/v1/clients/:id/policies

- Adds test for finding single client by id (show method), along with test for finding all policies by a single client.  All tests passing; 100% coverage.

- Adds show method for clients and index method for client policies.

- Adds show route for clients and index route for client policies.